### PR TITLE
feat: updates from v0.1.0 audit

### DIFF
--- a/client/errors/custom.ts
+++ b/client/errors/custom.ts
@@ -3,6 +3,7 @@ export type CustomError =
   | MaxParticipantsExceeded
   | InvalidEventParticipants
   | AuthorityMismatch
+  | InvalidTimestamp
 
 export class MaxStringLengthExceeded extends Error {
   static readonly code = 6000
@@ -48,6 +49,17 @@ export class AuthorityMismatch extends Error {
   }
 }
 
+export class InvalidTimestamp extends Error {
+  static readonly code = 6004
+  readonly code = 6004
+  readonly name = "InvalidTimestamp"
+  readonly msg = "Invalid timestamp"
+
+  constructor(readonly logs?: string[]) {
+    super("6004: Invalid timestamp")
+  }
+}
+
 export function fromCode(code: number, logs?: string[]): CustomError | null {
   switch (code) {
     case 6000:
@@ -58,6 +70,8 @@ export function fromCode(code: number, logs?: string[]): CustomError | null {
       return new InvalidEventParticipants(logs)
     case 6003:
       return new AuthorityMismatch(logs)
+    case 6004:
+      return new InvalidTimestamp(logs)
   }
 
   return null

--- a/client/types/CreateEventInfo.ts
+++ b/client/types/CreateEventInfo.ts
@@ -6,7 +6,6 @@ import * as borsh from "@coral-xyz/borsh"
 export interface CreateEventInfoFields {
   code: string
   name: string
-  participants: Array<number>
   expectedStartTimestamp: BN
   actualStartTimestamp: BN | null
   actualEndTimestamp: BN | null
@@ -15,7 +14,6 @@ export interface CreateEventInfoFields {
 export interface CreateEventInfoJSON {
   code: string
   name: string
-  participants: Array<number>
   expectedStartTimestamp: string
   actualStartTimestamp: string | null
   actualEndTimestamp: string | null
@@ -24,7 +22,6 @@ export interface CreateEventInfoJSON {
 export class CreateEventInfo {
   readonly code: string
   readonly name: string
-  readonly participants: Array<number>
   readonly expectedStartTimestamp: BN
   readonly actualStartTimestamp: BN | null
   readonly actualEndTimestamp: BN | null
@@ -32,7 +29,6 @@ export class CreateEventInfo {
   constructor(fields: CreateEventInfoFields) {
     this.code = fields.code
     this.name = fields.name
-    this.participants = fields.participants
     this.expectedStartTimestamp = fields.expectedStartTimestamp
     this.actualStartTimestamp = fields.actualStartTimestamp
     this.actualEndTimestamp = fields.actualEndTimestamp
@@ -43,7 +39,6 @@ export class CreateEventInfo {
       [
         borsh.str("code"),
         borsh.str("name"),
-        borsh.vec(borsh.u16(), "participants"),
         borsh.i64("expectedStartTimestamp"),
         borsh.option(borsh.i64(), "actualStartTimestamp"),
         borsh.option(borsh.i64(), "actualEndTimestamp"),
@@ -57,7 +52,6 @@ export class CreateEventInfo {
     return new CreateEventInfo({
       code: obj.code,
       name: obj.name,
-      participants: obj.participants,
       expectedStartTimestamp: obj.expectedStartTimestamp,
       actualStartTimestamp: obj.actualStartTimestamp,
       actualEndTimestamp: obj.actualEndTimestamp,
@@ -68,7 +62,6 @@ export class CreateEventInfo {
     return {
       code: fields.code,
       name: fields.name,
-      participants: fields.participants,
       expectedStartTimestamp: fields.expectedStartTimestamp,
       actualStartTimestamp: fields.actualStartTimestamp,
       actualEndTimestamp: fields.actualEndTimestamp,
@@ -79,7 +72,6 @@ export class CreateEventInfo {
     return {
       code: this.code,
       name: this.name,
-      participants: this.participants,
       expectedStartTimestamp: this.expectedStartTimestamp.toString(),
       actualStartTimestamp:
         (this.actualStartTimestamp && this.actualStartTimestamp.toString()) ||
@@ -93,7 +85,6 @@ export class CreateEventInfo {
     return new CreateEventInfo({
       code: obj.code,
       name: obj.name,
-      participants: obj.participants,
       expectedStartTimestamp: new BN(obj.expectedStartTimestamp),
       actualStartTimestamp:
         (obj.actualStartTimestamp && new BN(obj.actualStartTimestamp)) || null,

--- a/programs/protocol_event/src/error.rs
+++ b/programs/protocol_event/src/error.rs
@@ -10,4 +10,6 @@ pub enum EventError {
     InvalidEventParticipants,
     #[msg("Authority mismatch")]
     AuthorityMismatch,
+    #[msg("Invalid timestamp")]
+    InvalidTimestamp,
 }

--- a/programs/protocol_event/src/instructions/create_event.rs
+++ b/programs/protocol_event/src/instructions/create_event.rs
@@ -6,7 +6,6 @@ use anchor_lang::prelude::*;
 pub struct CreateEventInfo {
     pub code: String,
     pub name: String,
-    pub participants: Vec<u16>,
     pub expected_start_timestamp: i64,
     pub actual_start_timestamp: Option<i64>,
     pub actual_end_timestamp: Option<i64>,
@@ -18,10 +17,9 @@ pub fn create(
     authority: Pubkey,
     payer: Pubkey,
     subcategory: Pubkey,
-    subcategory_participant_count: u16,
     event_group: Pubkey,
 ) -> Result<()> {
-    validate_event(&event_info, subcategory_participant_count)?;
+    validate_event(&event_info)?;
 
     event.authority = authority;
     event.payer = payer;
@@ -34,7 +32,7 @@ pub fn create(
     event.code = event_info.code;
     event.name = event_info.name;
 
-    event.participants = event_info.participants;
+    event.participants = vec![];
 
     event.expected_start_timestamp = event_info.expected_start_timestamp;
     event.actual_start_timestamp = event_info.actual_start_timestamp;
@@ -43,7 +41,7 @@ pub fn create(
     Ok(())
 }
 
-fn validate_event(event_info: &CreateEventInfo, subcategory_participant_count: u16) -> Result<()> {
+fn validate_event(event_info: &CreateEventInfo) -> Result<()> {
     require!(
         event_info.name.len() <= Event::MAX_NAME_LENGTH,
         EventError::MaxStringLengthExceeded,
@@ -51,17 +49,6 @@ fn validate_event(event_info: &CreateEventInfo, subcategory_participant_count: u
     require!(
         event_info.code.len() <= Event::MAX_CODE_LENGTH,
         EventError::MaxStringLengthExceeded,
-    );
-    require!(
-        event_info.participants.len() <= Event::MAX_PARTICIPANTS,
-        EventError::MaxParticipantsExceeded,
-    );
-    require!(
-        event_info
-            .participants
-            .iter()
-            .all(|&participant| participant > 0 && participant <= subcategory_participant_count),
-        EventError::InvalidEventParticipants,
     );
     Ok(())
 }
@@ -94,7 +81,6 @@ mod tests {
         let event_info = CreateEventInfo {
             code: "LAFCvLAG@2021-08-28".to_string(),
             name: "Los Angeles Football Club vs. LA Galaxy".to_string(),
-            participants: vec![1, 2, 3, 4, 5],
             expected_start_timestamp: 1630156800,
             actual_start_timestamp: None,
             actual_end_timestamp: None,
@@ -110,7 +96,6 @@ mod tests {
             authority,
             authority,
             subcategory,
-            10,
             event_group,
         );
 
@@ -125,7 +110,7 @@ mod tests {
             new_event.name,
             "Los Angeles Football Club vs. LA Galaxy".to_string()
         );
-        assert_eq!(new_event.participants, vec![1, 2, 3, 4, 5]);
+        assert_eq!(new_event.participants, vec![]);
         assert_eq!(new_event.expected_start_timestamp, 1630156800);
         assert_eq!(new_event.actual_start_timestamp, None);
         assert_eq!(new_event.actual_end_timestamp, None);
@@ -136,13 +121,12 @@ mod tests {
         let event_info = CreateEventInfo {
             code: "LAFCvLAG@2021-08-28".to_string(),
             name: "012345678901234567890123456789012345678901234567890".to_string(),
-            participants: vec![],
             expected_start_timestamp: 1630156800,
             actual_start_timestamp: None,
             actual_end_timestamp: None,
         };
 
-        let result = validate_event(&event_info, 10);
+        let result = validate_event(&event_info);
 
         assert_eq!(result, Err(error!(EventError::MaxStringLengthExceeded)));
     }
@@ -152,48 +136,13 @@ mod tests {
         let event_info = CreateEventInfo {
             code: "012345678901234567890123456789".to_string(),
             name: "Los Angeles Football Club vs. LA Galaxy".to_string(),
-            participants: vec![],
             expected_start_timestamp: 1630156800,
             actual_start_timestamp: None,
             actual_end_timestamp: None,
         };
 
-        let result = validate_event(&event_info, 10);
+        let result = validate_event(&event_info);
 
         assert_eq!(result, Err(error!(EventError::MaxStringLengthExceeded)));
-    }
-
-    #[test]
-    fn test_validate_event_participants_exceeds_limit() {
-        let participants: Vec<u16> = (1..=301).map(|num| num as u16).collect();
-        let event_info = CreateEventInfo {
-            code: "LAFCvLAG@2021-08-28".to_string(),
-            name: "Los Angeles Football Club vs. LA Galaxy".to_string(),
-            participants,
-            expected_start_timestamp: 1630156800,
-            actual_start_timestamp: None,
-            actual_end_timestamp: None,
-        };
-
-        let result = validate_event(&event_info, 300);
-
-        assert_eq!(result, Err(error!(EventError::MaxParticipantsExceeded)));
-    }
-
-    #[test]
-    fn test_validate_event_participants_not_in_category() {
-        let participants: Vec<u16> = (1..=11).map(|num| num as u16).collect();
-        let event_info = CreateEventInfo {
-            code: "LAFCvLAG@2021-08-28".to_string(),
-            name: "Los Angeles Football Club vs. LA Galaxy".to_string(),
-            participants,
-            expected_start_timestamp: 1630156800,
-            actual_start_timestamp: None,
-            actual_end_timestamp: None,
-        };
-
-        let result = validate_event(&event_info, 10);
-
-        assert_eq!(result, Err(error!(EventError::InvalidEventParticipants)));
     }
 }

--- a/programs/protocol_event/src/instructions/create_grouping.rs
+++ b/programs/protocol_event/src/instructions/create_grouping.rs
@@ -22,11 +22,11 @@ pub fn create_category(
 
 fn validate_category(code: &String, name: &String) -> Result<()> {
     require!(
-        code.len() <= Subcategory::MAX_CODE_LENGTH,
+        code.len() <= Category::MAX_CODE_LENGTH,
         EventError::MaxStringLengthExceeded,
     );
     require!(
-        name.len() <= Subcategory::MAX_NAME_LENGTH,
+        name.len() <= Category::MAX_NAME_LENGTH,
         EventError::MaxStringLengthExceeded,
     );
     Ok(())

--- a/programs/protocol_event/src/instructions/update_grouping.rs
+++ b/programs/protocol_event/src/instructions/update_grouping.rs
@@ -13,7 +13,7 @@ pub fn increment_subcategory_participant_count(subcategory: &mut Subcategory) ->
 
 pub fn update_category_name(category: &mut Category, updated_name: String) -> Result<()> {
     require!(
-        updated_name.len() <= EventGroup::MAX_NAME_LENGTH,
+        updated_name.len() <= Category::MAX_NAME_LENGTH,
         EventError::MaxStringLengthExceeded,
     );
 
@@ -24,7 +24,7 @@ pub fn update_category_name(category: &mut Category, updated_name: String) -> Re
 
 pub fn update_subcategory_name(category: &mut Subcategory, updated_name: String) -> Result<()> {
     require!(
-        updated_name.len() <= EventGroup::MAX_NAME_LENGTH,
+        updated_name.len() <= Subcategory::MAX_NAME_LENGTH,
         EventError::MaxStringLengthExceeded,
     );
 

--- a/programs/protocol_event/src/lib.rs
+++ b/programs/protocol_event/src/lib.rs
@@ -24,7 +24,6 @@ pub mod protocol_event {
             ctx.accounts.authority.key(),
             ctx.accounts.authority.key(),
             ctx.accounts.subcategory.key(),
-            ctx.accounts.subcategory.participant_count,
             ctx.accounts.event_group.key(),
         )?;
         Ok(())

--- a/programs/protocol_event/src/state/category.rs
+++ b/programs/protocol_event/src/state/category.rs
@@ -1,4 +1,4 @@
-use crate::state::type_size::{vec_size, CHAR_SIZE, PUB_KEY_SIZE};
+use crate::state::type_size::{vec_size, CHAR_SIZE, DISCRIMINATOR_SIZE, PUB_KEY_SIZE};
 use anchor_lang::prelude::*;
 
 #[account]
@@ -13,7 +13,8 @@ impl Category {
     pub const MAX_CODE_LENGTH: usize = 8;
     pub const MAX_NAME_LENGTH: usize = 50;
 
-    pub const SIZE: usize = PUB_KEY_SIZE * 2
+    pub const SIZE: usize = DISCRIMINATOR_SIZE
+        + PUB_KEY_SIZE * 2
         + vec_size(CHAR_SIZE, Category::MAX_CODE_LENGTH)
         + vec_size(CHAR_SIZE, Category::MAX_NAME_LENGTH);
 }

--- a/programs/protocol_event/src/state/event_group.rs
+++ b/programs/protocol_event/src/state/event_group.rs
@@ -1,4 +1,4 @@
-use crate::state::type_size::{vec_size, CHAR_SIZE, PUB_KEY_SIZE};
+use crate::state::type_size::{vec_size, CHAR_SIZE, DISCRIMINATOR_SIZE, PUB_KEY_SIZE};
 use anchor_lang::prelude::*;
 
 #[account]
@@ -14,7 +14,8 @@ impl EventGroup {
     pub const MAX_CODE_LENGTH: usize = 8;
     pub const MAX_NAME_LENGTH: usize = 50;
 
-    pub const SIZE: usize = PUB_KEY_SIZE * 3
+    pub const SIZE: usize = DISCRIMINATOR_SIZE
+        + PUB_KEY_SIZE * 3
         + vec_size(CHAR_SIZE, EventGroup::MAX_CODE_LENGTH)
         + vec_size(CHAR_SIZE, EventGroup::MAX_NAME_LENGTH);
 }

--- a/programs/protocol_event/src/state/subcategory.rs
+++ b/programs/protocol_event/src/state/subcategory.rs
@@ -1,4 +1,4 @@
-use crate::state::type_size::{vec_size, CHAR_SIZE, PUB_KEY_SIZE, U16_SIZE};
+use crate::state::type_size::{vec_size, CHAR_SIZE, DISCRIMINATOR_SIZE, PUB_KEY_SIZE, U16_SIZE};
 use anchor_lang::prelude::*;
 
 #[account]
@@ -15,7 +15,8 @@ impl Subcategory {
     pub const MAX_CODE_LENGTH: usize = 8;
     pub const MAX_NAME_LENGTH: usize = 50;
 
-    pub const SIZE: usize = PUB_KEY_SIZE * 3
+    pub const SIZE: usize = DISCRIMINATOR_SIZE
+        + PUB_KEY_SIZE * 3
         + vec_size(CHAR_SIZE, Subcategory::MAX_CODE_LENGTH)
         + vec_size(CHAR_SIZE, Subcategory::MAX_NAME_LENGTH)
         + U16_SIZE;


### PR DESCRIPTION
Fixes for issues found during audit of v0.1.0
* [L-1] Duplicated participants - participants are now only added via `add_event_participants` instruction
* [L-2] Typo - correct account types now used
* [L-3] Discriminator size - discriminator now added when calculating account size
* [I-1] Time stamp validations - added missing validation

(see audit report for full details of issues)
