### PR TITLE
task: persist order of participants on event

### DIFF
--- a/tests/event/create_event.ts
+++ b/tests/event/create_event.ts
@@ -44,7 +44,7 @@ describe("Create Event", () => {
 
     // add participants
 
-    const participants = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const participants = [10, 1, 9, 7, 8, 6, 5, 4, 3, 2];
     await addEventParticipants(code, participants);
 
     const eventWithParticipants = await eventProgram.account.event.fetch(


### PR DESCRIPTION
- Persist the given order of the participant array on an event
- Retain dedupe capabilities to ensure only 1 of each participant on an event
- Update tests to reflect new functionality

![image](https://github.com/user-attachments/assets/f33e6f83-db01-4615-a94c-7b23ddb1035a)
