### PR TITLE
chore: rename update participant name

### DIFF
--- a/programs/protocol_event/src/instructions/update_participant.rs
+++ b/programs/protocol_event/src/instructions/update_participant.rs
@@ -12,7 +12,7 @@ pub fn update_code(participant: &mut Participant, code: String) -> Result<()> {
     Ok(())
 }
 
-pub fn update_name(participant: &mut Participant, name: String) -> Result<()> {
+pub fn update_participant_name(participant: &mut Participant, name: String) -> Result<()> {
     require!(
         name.len() <= Participant::MAX_NAME_LENGTH,
         EventError::MaxStringLengthExceeded,
@@ -54,14 +54,14 @@ mod tests {
     #[test]
     fn test_update_name() {
         let mut participant = &mut participant();
-        let result = update_name(&mut participant, "new name".to_string());
+        let result = update_participant_name(&mut participant, "new name".to_string());
         assert!(result.is_ok());
         assert_eq!(participant.name, "new name".to_string());
     }
 
     #[test]
     fn test_update_name_name_exceeds_limit() {
-        let result = update_name(
+        let result = update_participant_name(
             &mut participant(),
             "012345678901234567890123456789012345678901234567890".to_string(),
         );

--- a/programs/protocol_event/src/lib.rs
+++ b/programs/protocol_event/src/lib.rs
@@ -209,7 +209,7 @@ pub mod protocol_event {
         ctx: Context<UpdateParticipant>,
         updated_name: String,
     ) -> Result<()> {
-        instructions::update_participant::update_name(&mut ctx.accounts.participant, updated_name)
+        instructions::update_participant::update_participant_name(&mut ctx.accounts.participant, updated_name)
     }
 
     pub fn update_participant_code(

--- a/programs/protocol_event/src/lib.rs
+++ b/programs/protocol_event/src/lib.rs
@@ -209,7 +209,10 @@ pub mod protocol_event {
         ctx: Context<UpdateParticipant>,
         updated_name: String,
     ) -> Result<()> {
-        instructions::update_participant::update_participant_name(&mut ctx.accounts.participant, updated_name)
+        instructions::update_participant::update_participant_name(
+            &mut ctx.accounts.participant,
+            updated_name,
+        )
     }
 
     pub fn update_participant_code(


### PR DESCRIPTION
- Clippy wasn't happy that we were reusing `update_name` for event and participant

```
   |
11 | pub use update_event::*;
   |         ^^^^^^^^^^^^^^^ the name `update_name` in the value namespace is first re-exported here
12 | pub use update_grouping::*;
13 | pub use update_participant::*;
   |         --------------------- but the name `update_name` in the value namespace is also re-exported here
   |
   = note: `-D ambiguous-glob-reexports` implied by `-D warnings`

error: could not compile `protocol_event` (lib) due to previous error
```